### PR TITLE
Align API types and entrypoints with openapiv2.json spec

### DIFF
--- a/src/lib/cards/node/NodeOwner.svelte
+++ b/src/lib/cards/node/NodeOwner.svelte
@@ -2,15 +2,8 @@
 	import CardListEntry from '../CardListEntry.svelte';
 	import type { Node } from '$lib/common/types';
 	import OnlineUserIndicator from '$lib/parts/OnlineUserIndicator.svelte';
-	import { changeNodeOwner } from '$lib/common/api';
-	import { openDrawer, toastError, toastSuccess } from '$lib/common/funcs';
-	import { debug } from '$lib/common/debug';
-	import { getDrawerStore, getToastStore } from '@skeletonlabs/skeleton';
-	import { slide } from 'svelte/transition';
-
-	import RawMdiSwapHorizontal from '~icons/mdi/swap-horizontal';
-	import RawMdiCheckCircleOutline from '~icons/mdi/check-circle-outline';
-	import RawMdiCloseCircleOutline from '~icons/mdi/close-circle-outline';
+	import { openDrawer } from '$lib/common/funcs';
+	import { getDrawerStore } from '@skeletonlabs/skeleton';
 
 	import { App } from '$lib/States.svelte';
 
@@ -20,17 +13,11 @@
 	let { node }: NodeOwnerProps = $props()
 	
 	const drawerStore = getDrawerStore();
-	let transferUser = $state('');
-	let showTransfer = $state(false);
-	let transferring = $state(false);
-
-	const ToastStore = getToastStore();
 
 </script>
 
 <CardListEntry title="Owner:" top>
 	<div class="flex flex-row items-center gap-3 justify-end">
-		<!--button type="button" class="btn-sm ml-0"-->
 		<a
 			href=" "
 			onclick={() => {
@@ -39,65 +26,6 @@
 		>
 			{node.user.name}
 		</a>
-		<!--/button-->
 		<OnlineUserIndicator user={node.user} />
-		<button
-			type="button"
-			class="btn-sm btn-icon-sm ml-0"
-			onclick={() => {
-				showTransfer = !showTransfer;
-			}}
-		>
-			<RawMdiSwapHorizontal />
-		</button>
 	</div>
-	{#if showTransfer}
-		<div class="flex flex-row items-center justify-end pt-5" transition:slide>
-			<span class="pr-3">New Owner:</span>
-			<label class="label">
-				<select class="select" bind:value={transferUser}>
-					{#each App.users.value.filter(u => !!u.name) as user}
-						<option value={user.id}>{user.name}{!user.displayName ? '' : ` (${user.displayName})`}</option>
-					{/each}
-				</select>
-			</label>
-			<button
-				type="submit"
-				class="btn-sm btn-icon-sm"
-				disabled={transferring || transferUser == ''}
-				onclick={async () => {
-					transferring = true;
-					try {
-						const oldUserName = node.user.name;
-						const n = await changeNodeOwner(node, transferUser);
-						App.updateValue(App.nodes, n);
-						showTransfer = false;
-						toastSuccess(
-							`Changed owner of ${node.givenName} from "${oldUserName}" to "${n.user.name}"`,
-							ToastStore,
-						);
-					} catch (error) {
-						if (error instanceof Error) {
-							toastError('', ToastStore, error);
-						} else {
-							debug(error);
-						}
-					} finally {
-						transferring = false;
-					}
-				}}
-			>
-				<RawMdiCheckCircleOutline />
-			</button>
-			<button
-				type="button"
-				class="btn-sm btn-icon-sm"
-				onclick={() => {
-					showTransfer = false;
-				}}
-			>
-				<RawMdiCloseCircleOutline />
-			</button>
-		</div>
-	{/if}
 </CardListEntry>

--- a/src/lib/cards/node/NodeTags.svelte
+++ b/src/lib/cards/node/NodeTags.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
-	import { InputChip, getToastStore, popup, type PopupSettings } from '@skeletonlabs/skeleton';
+	import { InputChip, getToastStore } from '@skeletonlabs/skeleton';
 
 	import type { Node } from '$lib/common/types';
 	import { setNodeTags } from '$lib/common/api';
 	import { toastError } from '$lib/common/funcs';
 	import CardListEntry from '../CardListEntry.svelte';
-
-	import RawMdiWarning from '~icons/mdi/warning-outline';
 
 	import { App } from '$lib/States.svelte';
 
@@ -18,27 +16,16 @@
 		node = $bindable(),
 	}: NodeTagsProps = $props()
 
-	const tagsForced = $derived(node.forcedTags.map((tag) => tag.replace('tag:', '')));
-	const tagsValid = $derived(node.validTags.map((tag) => tag.replace('tag:', '')));
-	const tagsInvalid = $derived(node.invalidTags.map((tag) => tag.replace('tag:', '')));
+	const tags = $derived(node.tags.map((tag) => tag.replace('tag:', '')));
 
 	let disabled = $state(false);
-	let popupInvalidTagsShow = $state(false);
-
-	const popupInfo: PopupSettings = {
-		event: 'hover',
-		target: 'popupInvalidTags',
-		placement: 'top',
-	};
 
 	const ToastStore = getToastStore();
 
 	async function saveTags() {
 		disabled = true;
 		try {
-			const n = await setNodeTags(node, tagsForced);
-			n.validTags = [...tagsValid];
-			n.invalidTags = [...tagsInvalid];
+			const n = await setNodeTags(node, tags);
 			App.updateValue(App.nodes, n);
 		} catch (e) {
 			toastError('Invalid Tags: ' + e, ToastStore);
@@ -46,70 +33,18 @@
 			disabled = false;
 		}
 	}
-
-	let timerInfo: ReturnType<typeof setTimeout>;
-
-	function handleMouseEnter() {
-		timerInfo = setTimeout(() => {
-			popupInvalidTagsShow = true;
-		}, 333);
-	}
-
-	function handleMouseLeave() {
-		popupInvalidTagsShow = false;
-		clearTimeout(timerInfo);
-	}
 </script>
-
-<div
-	class="card p-3 rounded-md variant-filled-warning {popupInvalidTagsShow ? '' : 'invisible'}"
-	data-popup="popupInvalidTags"
->
-	<p>The following tags have been prevented by the current ACL:</p>
-	<p class="space-y-2 mt-2 text-left">
-		{#if popupInvalidTagsShow == true}
-			{#each tagsInvalid as tag}
-				<button type="button" class="chip variant-filled-error mr-2">{tag}</button>
-			{/each}
-		{/if}
-	</p>
-	<div class="arrow variant-filled-warning"></div>
-</div>
 
 <div class="space-y-4">
 	<CardListEntry top title="Tags:">
 		<InputChip
-			name="tags-forced-node-{node.id}"
+			name="tags-node-{node.id}"
 			{disabled}
-			value={tagsForced}
+			value={tags}
 			class="w-full"
 			chips="variant-filled-success"
 			on:add={saveTags}
 			on:remove={saveTags}
 		/>
-	</CardListEntry>
-	<CardListEntry top>
-		{#snippet childTitle()}
-		<span class="flex flex-row items-center">
-			Advertised Tags:
-			{#if tagsInvalid.length > 0}
-				<button
-					class="btn ml-2 btn-icon w-6 h-6 [&>*]:pointer-events-none"
-					use:popup={popupInfo}
-					onmouseenter={handleMouseEnter}
-					onmouseleave={handleMouseLeave}
-				>
-					<span class="text-warning-500">
-						<RawMdiWarning />
-					</span>
-				</button>
-			{/if}
-		</span>
-		{/snippet}
-		<div class="space-x-2 space-y-1">
-			{#each tagsValid as tag}
-				<button type="button" class="chip variant-filled-success">{tag}</button>
-			{/each}
-		</div>
 	</CardListEntry>
 </div>

--- a/src/lib/cards/user/UserListPreAuthKey.svelte
+++ b/src/lib/cards/user/UserListPreAuthKey.svelte
@@ -46,7 +46,7 @@
 			<Delete
 				func={async () => {
 					await expirePreAuthKey(preAuthKey);
-					const keys = await getPreAuthKeys([preAuthKey.user.id]);
+					const keys = await getPreAuthKeys();
 					keys.forEach((pak) => {
 						App.updateValue(App.preAuthKeys, pak)
 					});

--- a/src/lib/common/api/get.ts
+++ b/src/lib/common/api/get.ts
@@ -11,30 +11,10 @@ import type {
 import { debug } from '../debug';
 
 export async function getPreAuthKeys(
-	user_ids?: string[],
 	init?: RequestInit,
 ): Promise<PreAuthKey[]> {
-	if (user_ids == undefined) {
-		user_ids = (await getUsers(init)).map((u) => u.id);
-	}
-	const promises: Promise<ApiPreAuthKeys>[] = [];
-	let preAuthKeysAll: PreAuthKey[] = [];
-
-	user_ids.forEach(async (user_id: string) => {
-		if(user_id != ""){
-			promises.push(
-				apiGet<ApiPreAuthKeys>(API_URL_PREAUTHKEY + '?user=' + user_id, init),
-			);
-		}
-	});
-
-	promises.forEach(async (p) => {
-		const { preAuthKeys } = await p;
-		preAuthKeysAll = preAuthKeysAll.concat(preAuthKeys);
-	});
-
-	await Promise.all(promises);
-	return preAuthKeysAll;
+	const { preAuthKeys } = await apiGet<ApiPreAuthKeys>(API_URL_PREAUTHKEY, init);
+	return preAuthKeys;
 }
 
 type GetUserOptions = 

--- a/src/lib/common/api/modify.ts
+++ b/src/lib/common/api/modify.ts
@@ -29,16 +29,9 @@ export async function renameNode(n: Node, nameNew: string): Promise<Node> {
 	return node;
 }
 
-export async function changeNodeOwner(n: Node, newUserID: string): Promise<Node> {
-	const path = `${API_URL_NODE}/${n.id}/user`;
-	const { node } = await apiPost<ApiNode>(path, {user: newUserID});
-	debug('Re-assigned Node from "' + n.user.name + '" to "' + node.user.name + '"');
-	return node;
-}
-
 export async function expirePreAuthKey(pak: PreAuthKey) {
 	const path = `${API_URL_PREAUTHKEY}/expire`;
-	const data = { user: pak.user.id, key: pak.key };
+	const data = { id: pak.id };
 	await apiPost(path, data);
 }
 

--- a/src/lib/common/api/url.ts
+++ b/src/lib/common/api/url.ts
@@ -1,17 +1,17 @@
 export type ApiEndpoints = {
 	User: string;
 	Node: string;
-	Routes: string;
 	ApiKey: string;
 	PreAuthKey: string;
 	Policy: string;
+	Health: string;
 	Debug: string;
 };
 
 export const API_URL_USER = '/api/v1/user';
 export const API_URL_NODE = '/api/v1/node';
 export const API_URL_POLICY = '/api/v1/policy';
-export const API_URL_MACHINE = '/api/v1/machine';
 export const API_URL_APIKEY = '/api/v1/apikey';
 export const API_URL_PREAUTHKEY = '/api/v1/preauthkey';
+export const API_URL_HEALTH = '/api/v1/health';
 export const API_URL_DEBUG = '/api/v1/debug';

--- a/src/lib/common/funcs.ts
+++ b/src/lib/common/funcs.ts
@@ -408,8 +408,7 @@ export function filterNode(node: Node, filterString: string, onlineStatus: Onlin
 		return (
 			r.test(node.name) ||
 			r.test(node.givenName) ||
-			node.forcedTags.map(getTag).some((tag) => r.test(tag)) ||
-			node.validTags.map(getTag).some((tag) => r.test(tag))
+			node.tags.map(getTag).some((tag) => r.test(tag))
 		);
 	} catch (err) {
 		return true;

--- a/src/lib/common/types.ts
+++ b/src/lib/common/types.ts
@@ -133,23 +133,20 @@ export type Node = {
 	name: string;
 	user: User;
 	lastSeen: string | null;
-	lastSuccessfulUpdate: string | null;
 	expiry: string | null;
-	preAuthKey: string | null;
+	preAuthKey: PreAuthKey | null;
 	createdAt: string;
 	registerMethod:
 	| 'REGISTER_METHOD_UNSPECIFIED'
 	| 'REGISTER_METHOD_AUTH_KEY'
 	| 'REGISTER_METHOD_CLI'
 	| 'REGISTER_METHOD_OIDC';
-	forcedTags: string[];
-	invalidTags: string[];
-	validTags: string[];
 	givenName: string;
 	online: boolean;
 	approvedRoutes: string[];
 	availableRoutes: string[];
 	subnetRoutes: string[];
+	tags: string[];
 };
 
 export type ApiNodes = {
@@ -158,10 +155,6 @@ export type ApiNodes = {
 
 export type ApiNode = {
 	node: Node;
-};
-
-export type ApiMachine = {
-	machine: Node;
 };
 
 export type ApiKey = {


### PR DESCRIPTION
## Summary

Updates the frontend API layer and TypeScript types to match the current headscale `openapiv2.json` specification.

## Changes

### Type definitions (`types.ts`)
- **`Node.forcedTags`/`invalidTags`/`validTags`** → replaced with single **`tags: string[]`** (per `v1Node`)
- **`Node.lastSuccessfulUpdate`** → removed (not present in spec)
- **`Node.preAuthKey`** → changed from `string | null` to `PreAuthKey | null` (per `v1Node.preAuthKey` → `v1PreAuthKey`)
- Removed legacy **`ApiMachine`** type

### API entrypoints
- **`url.ts`** — removed `API_URL_MACHINE` (legacy `/api/v1/machine`); added `API_URL_HEALTH`; removed `Routes` from `ApiEndpoints`
- **`modify.ts`** — removed `changeNodeOwner()` (no `/api/v1/node/{id}/user` endpoint in spec); fixed `expirePreAuthKey()` to send `{ id }` per `v1ExpirePreAuthKeyRequest`
- **`get.ts`** — simplified `getPreAuthKeys()` to a single `GET /api/v1/preauthkey` call (spec lists no required query params)

### Components
- **`NodeTags.svelte`** — uses unified `node.tags` array; removed invalid-tags warning popup
- **`NodeOwner.svelte`** — removed transfer-owner UI (endpoint no longer in spec)
- **`UserListPreAuthKey.svelte`** — updated `getPreAuthKeys()` call signature
- **`funcs.ts`** — updated node tag filtering to use `node.tags`